### PR TITLE
Update VEP TSO500 config to VEP v107

### DIFF
--- a/tso500_vep_config_v1.1.0.json
+++ b/tso500_vep_config_v1.1.0.json
@@ -2,12 +2,12 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.0.2"
+        "config_version": "1.1.0"
     },
         "vep_resources":{
-        "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",
-        "plugin_config":"file-G9jZpk8433GvFvX14P775324",
-        "vep_cache":"file-G8V4bGj433Gz96K3Fb1VfbG3",
+        "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
+        "plugin_config":"file-GQ7Yzz04XB7q1vZyY9pQGyjp",
+        "vep_cache":"file-GQ7YF104GV6YQ0B98qyQQP58",
         "reference_fasta":"file-G6BYyyj4YV3pYBkgFVGP2K4P",
         "reference_fai":"file-G6P32kj4YV3y58KyP4k4qG2p",
         "reference_gzi":"file-G6BYz104YV3X5qp463K5b5vp",
@@ -60,7 +60,7 @@
     "plugins": [
     {
         "name": "SpliceAI",
-        "pm_file": "file-G8YXQQQ4jKX4bVz53zK7VJX5",
+        "pm_file": "file-GQ7ZJK04vfJVPB7FKybkx0yk",
         "required_fields":"SpliceAI_pred_DS_AG,SpliceAI_pred_DS_AL,SpliceAI_pred_DS_DG,SpliceAI_pred_DS_DL,SpliceAI_pred_DP_AG,SpliceAI_pred_DP_AL,SpliceAI_pred_DP_DG,SpliceAI_pred_DP_DL",
         "suffix": "cutoff=0.5",
         "resource_files": [
@@ -78,7 +78,7 @@
       },
       {
         "name": "REVEL",
-        "pm_file": "file-G9b5pxQ4jKXGP22y4byPpqq8",
+        "pm_file": "file-GQ7Zf4047GqpFvkbQ5X4p535",
         "required_fields":"REVEL",
         "resource_files": [
           {
@@ -100,7 +100,7 @@
       },
       {
         "name": "CADD",
-        "pm_file": "file-G6BYQGQ433Gg0KfZF5xPfv1X",
+        "pm_file": "file-GQ7ZY6841Jgv0Q5PkBbypJy0",
         "required_fields":"CADD_PHRED",
         "resource_files": [
           {


### PR DESCRIPTION
Updating VEP TSO500 config from using VEP version 105 to 107

- Updated version in filename from tso500_vep_config_v1.0.2.json to tso500_vep_config_v1.1.0.json
- Updated config version within the file from v1.0.2 to v1.1.0
- Replaced file IDs for vep_docker, plugin_config and vep_cache
- Replaced file IDs for REVEL, CADD and SpliceAI .pm files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_helios_config/5)
<!-- Reviewable:end -->
