### PR TITLE
updated clinvar config file reference to version 20230520

### DIFF
--- a/tso500_vep_config_v1.1.2.json
+++ b/tso500_vep_config_v1.1.2.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.1.1"
+        "config_version": "1.1.2"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GQzBBpj4jJkp94yG3yBbJyV6",
-          "index_id":"file-GQzBGF840vgp94yG3yBbJyk7"
+          "file_id":"file-GVfFQVQ4FX0Y9bzPG5YXpqZJ",
+          "index_id":"file-GVfFXP04kKb0vy5y0yb8VypG"
           }
         ]
       },


### PR DESCRIPTION
Changes:

- Config version updated from `v1.1.1` to `v1.1.2`
- ClinVar file reference updated to `20230520` release

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_helios_config/7)
<!-- Reviewable:end -->
