### PR TITLE
Update ClinVar b37 to 20230617

### DIFF
--- a/tso500_vep_config_v1.1.3.json
+++ b/tso500_vep_config_v1.1.3.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.1.2"
+        "config_version": "1.1.3"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GVfFQVQ4FX0Y9bzPG5YXpqZJ",
-          "index_id":"file-GVfFXP04kKb0vy5y0yb8VypG"
+          "file_id":"file-GX8j5pj4b1z1gV8qjqYj5QFX",
+          "index_id":"file-GX8j5yj4b1zFZ0k9Y2X7P5vb"
           }
         ]
       },


### PR DESCRIPTION
Updates:

- `config_version` was updated from v1.1.2 to v1.1.3
- clinvar files `fild_id` and `index_id` were updated to point to the most recent Clinvar annotation files (version 20230617)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_helios_config/8)
<!-- Reviewable:end -->
