### PR TITLE
Update ClinVar b37 to 20230617 with bug fix

### DIFF
--- a/tso500_vep_config_v1.1.3.json
+++ b/tso500_vep_config_v1.1.3.json
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GX8j5pj4b1z1gV8qjqYj5QFX",
-          "index_id":"file-GX8j5yj4b1zFZ0k9Y2X7P5vb"
+          "file_id":"file-GXBpzk84b1z1bgzyV6Xj2Jzf",
+          "index_id":"file-GXBpzq04b1z1XYy36z9yYgZK"
           }
         ]
       },


### PR DESCRIPTION
Updates:

- included a bug fix to update ClinVar files `fild_id` and `index_id` to point to the most recent Clinvar annotation files (version 20230617)