### PR TITLE
Update ClinVar b37 to 20230717

### DIFF
--- a/tso500_vep_config_v1.1.4.json
+++ b/tso500_vep_config_v1.1.4.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.1.3"
+        "config_version": "1.1.4"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GXBpzk84b1z1bgzyV6Xj2Jzf",
-          "index_id":"file-GXBpzq04b1z1XYy36z9yYgZK"
+          "file_id":"file-GXpQkgQ4Xb45Q36644FY48qk",
+          "index_id":"file-GXpQpY04qqK5pK0z04k6175B"
           }
         ]
       },


### PR DESCRIPTION
- config_version was updated from v1.1.3 to v1.1.4
- Clinvar files fild_id and index_id were updated to point to the most recent ClinVar annotation files (file-GXBpzk84b1z1bgzyV6Xj2Jzf and file-GXBpzq04b1z1XYy36z9yYgZK)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_helios_config/10)
<!-- Reviewable:end -->
