### PR TITLE
Update eggd_VEP config for TSO500 - v.1.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
   * hs37d5.fasta-index.tar.gz
 * Custom Annotation sources:
-  * clinvar_20240215_GRCh37.vcf.gz
+  * clinvar_20240317_GRCh37.vcf.gz
   * gnomad.genomes.r2.0.1.sites.noVEP_normalised_decomposed_PASS.vcf.gz
   * gnomad.exomes.r2.0.2.sites.noVEP_normalised_decomposed_PASS.vcf.gz
 * Plugin annotations:

--- a/tso500_vep_config_v1.2.6.json
+++ b/tso500_vep_config_v1.2.6.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.2.5"
+        "config_version": "1.2.6"
     },
         "vep_resources":{
         "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",
@@ -24,7 +24,7 @@
         "resource_files": [
           {
           "file_id":"file-Gg9Y8Vj4gqZF51Bk1YGypX2p",
-          "index_id":"file-Gg9YBYQ4G3QYXQ9JgvqgYfq6"
+          "index_id":"file-Ggv03804qk96Yk0zv0jj147x"
           }
         ]
       },

--- a/tso500_vep_config_v1.2.6.json
+++ b/tso500_vep_config_v1.2.6.json
@@ -23,7 +23,7 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-Gg9Y8Vj4gqZF51Bk1YGypX2p",
+          "file_id":"file-Ggv012Q4xy8GZpQY0Gz72vKJ",
           "index_id":"file-Ggv03804qk96Yk0zv0jj147x"
           }
         ]


### PR DESCRIPTION
- config_version was updated from v1.2.5 to v1.2.6

- Updated ClinVar annotation resource file to the release 20240317 (see the following link for details of base testing of annotation source) https://cuhbioinformatics.atlassian.net/wiki/spaces/DV/pages/3146153985/240318+update+Clinvar+annotation+source+GRCh37+version+20240317

- The README file is updated to point to the updated ClinVar file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_helios_config/22)
<!-- Reviewable:end -->
