### PR TITLE
update to use ClinVar GRCh37 version20240611

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
   * hs37d5.fasta-index.tar.gz
 * Custom Annotation sources:
-  * clinvar_20240407_GRCh37.vcf.gz
+  * clinvar_20240611_GRCh37.vcf.gz
   * gnomad.genomes.r2.0.1.sites.noVEP_normalised_decomposed_PASS.vcf.gz
   * gnomad.exomes.r2.0.2.sites.noVEP_normalised_decomposed_PASS.vcf.gz
 * Plugin annotations:

--- a/tso500_vep_config_v1.2.8.json
+++ b/tso500_vep_config_v1.2.8.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.2.7"
+        "config_version": "1.2.8"
     },
         "vep_resources":{
         "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GjKJpy0460YKpKYJ7F4k0Yyv",
-          "index_id":"file-GjKJq9Q43BbXqyYkPQ9ZBZx5"
+          "file_id":"file-GkgyF3j4JV8FzFzBjqzKb6Gb",
+          "index_id":"file-GkgyFk84PPP9920v5x48JBpY"
           }
         ]
       },


### PR DESCRIPTION
Changes:

- Update clinvar version in README to clinvar_20240611_GRCh37.vcf.gz
- Update config version from v1.2.6 to v1.2.7
- Update clinvar annotation resource file_ID and index_ID