### PR TITLE
Update Clinvar to version 20240813

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
   * hs37d5.fasta-index.tar.gz
 * Custom Annotation sources:
-  * clinvar_20240708_GRCh37.vcf.gz
+  * clinvar_20240813_GRCh37.vcf.gz
   * gnomad.genomes.r2.0.1.sites.noVEP_normalised_decomposed_PASS.vcf.gz
   * gnomad.exomes.r2.0.2.sites.noVEP_normalised_decomposed_PASS.vcf.gz
 * Plugin annotations:

--- a/tso500_vep_config_v1.2.10.json
+++ b/tso500_vep_config_v1.2.10.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.2.9"
+        "config_version": "1.2.10"
     },
         "vep_resources":{
         "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GpBQGV04bjFyff7J639Gf748",
-          "index_id":"file-GpBQKKj46v4qkxvQ92P7q2z6"
+          "file_id":"file-Gq1Y1q04pZJXkF96B908F6JY",
+          "index_id":"file-Gq1Y2P049Kp2Jq880x258qqG"
           }
         ]
       },


### PR DESCRIPTION
TSO500_vep_config file was renamed by using git mv to increase version in the filename (i.e. from v1.2.9 to v1.2.10). Within the file:
- config_version was updated from v1.2.9 to v1.2.10
- ClinVar files file_id and index_id were updated to point to the most recent ClinVar annotation files (file-Gq1Y1q04pZJXkF96B908F6JY and file-Gq1Y2P049Kp2Jq880x258qqG)
- README file was updated to point to the correct ClinVar files.