### PR TITLE
Ng 784 v1.2.31 update vep config to include latest clinvar release (20260510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This json file provides information about annotations,plugins, required fields a
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
   * hs37d5.fasta-index.tar.gz
 * Custom Annotation sources:
-  * clinvar_20260404_GRCh37.vcf.gz
+  * clinvar_20260510_GRCh37.vcf.gz
   * gnomad.genomes.r2.0.1.sites.noVEP_normalised_decomposed_PASS.vcf.gz
   * gnomad.exomes.r2.0.2.sites.noVEP_normalised_decomposed_PASS.vcf.gz
 * Plugin annotations:

--- a/tso500_vep_config_v1.2.31.json
+++ b/tso500_vep_config_v1.2.31.json
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-J7KV68Q4Pb2XPqx29Xjpb4Zv",
-          "index_id":"file-J7KVGxQ40V15KvZvbYpqX1P6"
+          "file_id":"file-J81Pq7Q4Jy1YpQX8YF00zb3J",
+          "index_id":"file-J81Pvyj48gJBQq5ZqzxBZ37J"
           }
         ]
       },

--- a/tso500_vep_config_v1.2.31.json
+++ b/tso500_vep_config_v1.2.31.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"TSO500",
-        "config_version": "1.2.30"
+        "config_version": "1.2.31"
     },
         "vep_resources":{
         "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",


### PR DESCRIPTION
Changes:

- update the config to include most recent clinvar b37 release (clinvar 20260510)
- update version inside the config and filename to v1.2.31
- update readme

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_helios_config/47)
<!-- Reviewable:end -->
